### PR TITLE
Updating Discount card title to Discount code

### DIFF
--- a/qr-code/node/web/frontend/pages/codes/new.jsx
+++ b/qr-code/node/web/frontend/pages/codes/new.jsx
@@ -234,7 +234,7 @@ export default function NewCode() {
               </Card>
               <Card
                 sectioned
-                title="Discount"
+                title="Discount code"
                 actions={[
                   {
                     content: 'Create discount',


### PR DESCRIPTION
Changing the **Discount** card title to be **Discount code** so that it's clearer that discount codes are the only type of discounts that can be applied to a QR code destination.