### PR TITLE
Hiding variants in ResourcePicker

### DIFF
--- a/qr-code/node/web/frontend/components/CodeEditForm.jsx
+++ b/qr-code/node/web/frontend/components/CodeEditForm.jsx
@@ -230,6 +230,7 @@ export function CodeEditForm({ id, initialValues }) {
                   {showResourcePicker && (
                     <ResourcePicker
                       resourceType="Product"
+                      showVariants={false}
                       selectMultiple={false}
                       onCancel={toggleResourcePicker}
                       onSelection={handleProductChange}

--- a/qr-code/node/web/frontend/pages/codes/new.jsx
+++ b/qr-code/node/web/frontend/pages/codes/new.jsx
@@ -230,6 +230,7 @@ export default function NewCode() {
                   {showResourcePicker && (
                     <ResourcePicker
                       resourceType="Product"
+                      showVariants={false}
                       selectMultiple={false}
                       onCancel={toggleResourcePicker}
                       onSelection={handleProductChange}


### PR DESCRIPTION
Hide the variants from the Resource Picker, because it would otherwise allow users to select multiple variants at once - which our app doesn’t support.

Resolves [#283](https://github.com/Shopify/first-party-library-planning/issues/283).