### PR TITLE
chore: change the way way navigate is called when creating a new discount

### DIFF
--- a/qr-code/node/shopify.app.toml
+++ b/qr-code/node/shopify.app.toml
@@ -1,5 +1,5 @@
 # This file stores configurations for your Shopify app.
 
-name = "Test App"
-id = "8d796e39b66b3a14e34f84a9f09b63c0"
+name = "test-app"
+id = "329c4a7616245b7c1c527d75599b4f4f"
 scopes = "write_products,read_discounts"

--- a/qr-code/node/web/frontend/pages/codes/new.jsx
+++ b/qr-code/node/web/frontend/pages/codes/new.jsx
@@ -20,7 +20,6 @@ import {
   TitleBar,
   ResourcePicker,
   useNavigate,
-  useAppBridge,
 } from '@shopify/app-bridge-react'
 import { ImageMajor, AlertMinor } from '@shopify/polaris-icons'
 import { useShopifyQuery } from 'hooks/useShopifyQuery'
@@ -128,8 +127,6 @@ export default function NewCode() {
       }
     },
   })
-
-  const app = useAppBridge()
 
   const handleProductChange = useCallback(({ id, selection }) => {
     // TODO: Storing product details, and product ID seperately is a hack
@@ -297,7 +294,12 @@ export default function NewCode() {
                   {
                     content: 'Create discount',
                     onAction: () =>
-                      navigate(`${app.hostOrigin}/admin/discounts`),
+                      navigate({
+                        name: 'Discount',
+                        resource: {
+                          create: true,
+                        }
+                      })
                   },
                 ]}
               >


### PR DESCRIPTION
## Background

Closes https://github.com/Shopify/first-party-library-planning/issues/249

The `navigate` function returned from App Bridge's `useNavigate` hook can be used in several ways: passing a simple path or passing an object that points to a specific resource in Admin. We were previously having trouble making the resource-in-admin approach work, but it seems to work now (probably user error 😬 ).

## Solution

Update the way that we call `navigate` to take advantage of the more declarative approach to navigating within Admin. This change also allows us to remove the `useAppBridge` hook in the `new` component. 

## Testing this PR

- Run app: `yarn dev --tunnel`
- Click on on "Create QR code" button to navigate to `/new`
- Click on "Create discount" link -- it should navigate to `discounts/new`

Question: Should this open in a new tab? 
