### PR TITLE
feat: Add delete button on edit page

### DIFF
--- a/qr-code/node/web/frontend/components/CodeEditForm.jsx
+++ b/qr-code/node/web/frontend/components/CodeEditForm.jsx
@@ -14,14 +14,12 @@ import {
   Icon,
   Stack,
   TextStyle,
-  Image,
 } from '@shopify/polaris'
 import {
   ContextualSaveBar,
   TitleBar,
   ResourcePicker,
   useNavigate,
-  useAppBridge,
 } from '@shopify/app-bridge-react'
 import { ImageMajor, AlertMinor } from '@shopify/polaris-icons'
 import { useShopifyQuery } from 'hooks/useShopifyQuery'
@@ -129,8 +127,6 @@ export function CodeEditForm({ id, initialValues }) {
     },
   })
 
-  const app = useAppBridge()
-
   const handleProductChange = useCallback(({ id, selection }) => {
     // TODO: Storing product details, and product ID seperately is a hack
     // This will be fixed when this form queries the product data
@@ -166,6 +162,17 @@ export function CodeEditForm({ id, initialValues }) {
       first: 25,
     },
   })
+
+  async function deleteQRCode() {
+    const response = await fetch(`/api/qrcodes/${id}`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    if (response.ok) {
+      navigate(`/`)
+    }
+  }
 
   const discountOptions = discounts
     ? [
@@ -204,7 +211,7 @@ export function CodeEditForm({ id, initialValues }) {
       <TitleBar title="New code" primaryAction={null} />
       <Layout>
         <Layout.Section>
-          <Form onSubmit={() => console.log('hi')}>
+          <Form>
             <FormLayout>
               <Card sectioned title="Title">
                 <TextField
@@ -297,7 +304,12 @@ export function CodeEditForm({ id, initialValues }) {
                   {
                     content: 'Create discount',
                     onAction: () =>
-                      navigate(`${app.hostOrigin}/admin/discounts`),
+                    navigate({
+                      name: 'Discount',
+                      resource: {
+                        create: true,
+                      }
+                    }, {target: 'new'})
                   },
                 ]}
               >
@@ -310,6 +322,9 @@ export function CodeEditForm({ id, initialValues }) {
                   labelHidden
                 />
               </Card>
+              <Button outline destructive onClick={deleteQRCode}>
+                Delete QR code
+              </Button>
             </FormLayout>
           </Form>
         </Layout.Section>

--- a/qr-code/node/web/frontend/pages/codes/new.jsx
+++ b/qr-code/node/web/frontend/pages/codes/new.jsx
@@ -299,7 +299,7 @@ export default function NewCode() {
                         resource: {
                           create: true,
                         }
-                      })
+                      }, {target: 'new'})
                   },
                 ]}
               >


### PR DESCRIPTION
## Background

Closes https://github.com/Shopify/first-party-library-planning/issues/272

We should be able to delete a QR code from the `edit` page.

## Solution

- Add a delete button
- Send a delete request to the API
- Redirect to the root if delete was successful

![Screen Shot 2022-05-25 at 10 36 02 AM](https://user-images.githubusercontent.com/7654369/170316758-37d026fc-209c-4004-9f08-930ba3606d9a.png)

### Unrelated follow up to https://github.com/Shopify/shopify-app-examples/pull/45
 
- Open "Create discount" link in new tab (on `new` page)
- Copy implementation of navigate to `edit` page (just missed this on the last PR)

## Testing this PR

- Run app: `yarn dev --tunnel`
- Click on "Create QR code" button to navigate to `/new`
- Create a QR code
- You will be redirected to edit
- Click on "Delete QR Code" link
- You should be redirected to the root

Note that we currently have the table hard-coded to always show in the index rather than the empty state (this will my next fix), but the table should not have the QR code that you just deleted. 