### PR TITLE
Changes backend to listen on either BACKEND_PORT or PORT

### DIFF
--- a/qr-code/node/web/backend/index.js
+++ b/qr-code/node/web/backend/index.js
@@ -13,7 +13,7 @@ import { setupGDPRWebHooks } from "./gdpr.js";
 const USE_ONLINE_TOKENS = true;
 const TOP_LEVEL_OAUTH_COOKIE = "shopify_top_level_oauth";
 
-const PORT = parseInt(process.env.BACKEND_PORT, 10);
+const PORT = parseInt(process.env.BACKEND_PORT || process.env.PORT, 10);
 const isTest = process.env.NODE_ENV === "test" || !!process.env.VITE_TEST_BUILD;
 
 // TODO: There should be provided by env vars


### PR DESCRIPTION
### WHY are these changes introduced?

Some environments (e.g., Heroku) don't allow choice of port to listen to - they dynamically allocate a port and set it to the environment variable `PORT` for the app to read.

### WHAT is this pull request doing?

Changed the `web/backend/index.js` file to listen on either `BACKEND_PORT` or `PORT` from the environment to support CLI, manual and deployments.