### PR TITLE
Fix Vite reloads crashing AppBridge

### DIFF
--- a/qr-code/node/web/frontend/components/providers/AppBridgeProvider.jsx
+++ b/qr-code/node/web/frontend/components/providers/AppBridgeProvider.jsx
@@ -2,6 +2,8 @@ import { useMemo, useRef } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { Provider } from '@shopify/app-bridge-react'
 
+const APPBRIDGE_HOST = new URLSearchParams(location.search).get('host')
+
 export function AppBridgeProvider({ children }) {
   const location = useLocation()
   const navigate = useNavigate()
@@ -19,15 +21,11 @@ export function AppBridgeProvider({ children }) {
     [history, location]
   )
 
-  const { current: host } = useRef(
-    new URL(window.location).searchParams.get('host')
-  )
-
   return (
     <Provider
       config={{
         apiKey: process.env.SHOPIFY_API_KEY,
-        host,
+        host: APPBRIDGE_HOST,
         forceRedirect: true,
       }}
       router={routerConfig}


### PR DESCRIPTION
This hoists the `?host` querystring parameter detection so that it only runs once when modules are initialized, rather than any time the React tree is remounted, which crashes AppBridge due to it being a singleton.