### PR TITLE
Chore: Add missing useEffect dependencies

### DIFF
--- a/qr-code/node/web/frontend/pages/codes/edit/[id].jsx
+++ b/qr-code/node/web/frontend/pages/codes/edit/[id].jsx
@@ -22,14 +22,14 @@ export default function CodeEdit() {
   const { id } = useParams()
 
   useEffect(async () => {
-    if(QRCode) return;
-    const response = await fetch(`/api/qrcodes/${id}`, { method: 'GET' })
+    if (QRCode) return
+    const response = await fetch(`/api/qrcodes/${id}`)
 
     if (response.ok) {
       const body = await response.json()
       setQRCode(body)
     }
-  }, [])
+  }, [id, QRCode])
 
   if (!QRCode) {
     return (


### PR DESCRIPTION
This should be a non-functional change, since the Edit route is only ever loaded using React Router, which forces remounting of components any time the URL changes (even when the resolved route is the same for subsequent URLs).

It might be good to have an eslint config in the scaffolded template that includes [eslint-plugin-react-hooks](https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks) to help developers with this too (the "Exhaustive Deps" rule).