### PR TITLE
Feature/stale while revalidate

### DIFF
--- a/qr-code/node/web/frontend/pages/index.jsx
+++ b/qr-code/node/web/frontend/pages/index.jsx
@@ -13,14 +13,17 @@ import { useAuthenticatedFetch } from '../hooks/useAuthenticatedFetch'
 
 import { CodeIndex } from '../components/CodeIndex'
 
+let cachedQRCodes = null
+
 export default function HomePage() {
   const navigate = useNavigate()
   const fetch = useAuthenticatedFetch()
   const [loading, setLoading] = useState(true)
-  const [QRCodes, setQRCodes] = useState([])
+  const [QRCodes, setQRCodes] = useState(cachedQRCodes)
 
   useEffect(async () => {
     const codes = await fetch('/api/qrcodes').then((res) => res.json())
+    cachedQRCodes = codes
     setLoading(false)
     setQRCodes(codes)
   }, [])
@@ -28,37 +31,37 @@ export default function HomePage() {
   return (
     <Frame>
       {loading && <Loading />}
-    <Page>
-      <TitleBar
-        primaryAction={{
-          content: 'Create QR code',
-          onAction: () => navigate('/codes'),
-        }}
-      />
-      <Layout>
-        <Layout.Section>
-          {QRCodes.length ? (
-            <CodeIndex QRCodes={QRCodes} />
-          ) : (
-            <Card sectioned>
-              <EmptyState
-                heading="Create unique QR codes for your product"
-                action={{
-                  content: 'Create QR code',
-                  onAction: () => navigate('/codes'),
-                }}
-                image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
-              >
-                <p>
-                  Allow customers to scan codes and buy products using their
-                  phones.
-                </p>
-              </EmptyState>
-            </Card>
-          )}
-        </Layout.Section>
-      </Layout>
-    </Page>
+      <Page>
+        <TitleBar
+          primaryAction={{
+            content: 'Create QR code',
+            onAction: () => navigate('/codes'),
+          }}
+        />
+        <Layout>
+          <Layout.Section>
+            {QRCodes && QRCodes.length ? (
+              <CodeIndex QRCodes={QRCodes} />
+            ) : (
+              <Card sectioned>
+                <EmptyState
+                  heading="Create unique QR codes for your product"
+                  action={{
+                    content: 'Create QR code',
+                    onAction: () => navigate('/codes'),
+                  }}
+                  image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
+                >
+                  <p>
+                    Allow customers to scan codes and buy products using their
+                    phones.
+                  </p>
+                </EmptyState>
+              </Card>
+            )}
+          </Layout.Section>
+        </Layout>
+      </Page>
     </Frame>
   )
 }


### PR DESCRIPTION
This PR adds a loading indicator to the index / QR Codes listing page, and adds a rudimentary Stale While Revalidate pattern to display previous cached listings while refetching a fresh list.

> **Devil's Advocate:** Using a module global to store cached data isn't great, but in this case the only drawback is testability. It's possible to add a nice cache implementation, but my guess is that would blow up the scope of this template and make it harder to understand.

#### Before:

Navigating to Edit, then hitting the `Back` button shows an empty state while the list of QR codes is fetched:

https://user-images.githubusercontent.com/105127/171055061-ce6f44d1-bb40-4f21-8c1b-1482e3824684.mov

#### After:

Navigating to Edit, then hitting the `Back` button shows a cached list of QR codes while a fresh listing is fetched:


https://user-images.githubusercontent.com/105127/171055157-3df36e7e-698a-45f1-9396-923165362743.mov

