### PR TITLE
Remove uppercase from multi-word labels

### DIFF
--- a/qr-code/node/web/frontend/components/CodeEditForm.jsx
+++ b/qr-code/node/web/frontend/components/CodeEditForm.jsx
@@ -384,7 +384,7 @@ export function CodeEditForm({ QRCode, setQRCode }) {
               onClick={goToDestination}
               disabled={!handle.value}
             >
-              Go To Destination
+              Go to destination
             </Button>
           </Stack>
         </Card>


### PR DESCRIPTION
UX guidance is that multi-word labels only use uppercase on the first word.