### PR TITLE
Make IndexTable row a link

### DIFF
--- a/qr-code/node/web/frontend/components/CodeIndex.jsx
+++ b/qr-code/node/web/frontend/components/CodeIndex.jsx
@@ -1,8 +1,10 @@
-import { Card, IndexTable, Thumbnail, Link } from '@shopify/polaris'
+import { useNavigate } from '@shopify/app-bridge-react'
+import { Card, IndexTable, Thumbnail, UnstyledLink } from '@shopify/polaris'
 import { ShopcodesMajor } from '@shopify/polaris-icons'
 import dayjs from 'dayjs'
 
 export function CodeIndex({ QRCodes }) {
+  const navigate = useNavigate()
   const resourceName = {
     singular: 'code',
     plural: 'codes',
@@ -13,7 +15,14 @@ export function CodeIndex({ QRCodes }) {
       { id, title, product, discountCode, scans, createdAt },
       index
     ) => (
-      <IndexTable.Row id={id} key={id} position={index}>
+      <IndexTable.Row
+        id={id}
+        key={id}
+        position={index}
+        onClick={() => {
+          navigate(`/codes/edit/${id}`)
+        }}
+      >
         <IndexTable.Cell>
           <Thumbnail
             source={product?.images?.edges[0]?.node?.url || ShopcodesMajor}
@@ -22,7 +31,9 @@ export function CodeIndex({ QRCodes }) {
           />
         </IndexTable.Cell>
         <IndexTable.Cell>
-          <Link url={`/codes/edit/${id}`}>{title}</Link>
+          <UnstyledLink data-primary-link url={`/codes/edit/${id}`}>
+            {title}
+          </UnstyledLink>
         </IndexTable.Cell>
         <IndexTable.Cell>{product.title}</IndexTable.Cell>
         <IndexTable.Cell>{discountCode}</IndexTable.Cell>

--- a/qr-code/node/web/frontend/components/providers/PolarisProvider.jsx
+++ b/qr-code/node/web/frontend/components/providers/PolarisProvider.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from '@shopify/app-bridge-react'
 import translations from '@shopify/polaris/locales/en.json'
 import '@shopify/polaris/build/esm/styles.css'
 
-function AppBridgeLink({ url, children, className, external, ...rest }) {
+function AppBridgeLink({ url, children, external, ...rest }) {
   const navigate = useNavigate()
   const handleClick = useCallback(() => {
     navigate(url)
@@ -21,7 +21,7 @@ function AppBridgeLink({ url, children, className, external, ...rest }) {
   }
 
   return (
-    <a onClick={handleClick} {...{ className }}>
+    <a onClick={handleClick} {...rest}>
       {children}
     </a>
   )

--- a/qr-code/node/web/frontend/package.json
+++ b/qr-code/node/web/frontend/package.json
@@ -16,7 +16,7 @@
     "@shopify/app-bridge": "^2.0.25",
     "@shopify/app-bridge-react": "^2.0.25",
     "@shopify/app-bridge-utils": "^2.0.25",
-    "@shopify/polaris": "^9.2.2",
+    "@shopify/polaris": "^9.11.0",
     "@shopify/react-form": "^1.1.19",
     "@vitejs/plugin-react": "1.2.0",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
This is a little confusing. So I'll break it down:

1. We make the title a link to the edit page.
2. Next we add the `data-primary-link` attribute to that link.  This tells the Row what the URL for that row is.  For this attribute to be applied I needed to update the implementation of our custom Link component so that it applies that attribute. (I'll update the template)
3. Confusingly, the row doesn't use that link because we pass an onClick prop to the Row.  But.. confusingly the Row knows it is clickable by the fact that that attribute exists.
4. When onClick is called we call navigate from useNavigate() to navigate to the correct page.  We had to update Polaris to get access to the onClick prop.

So, it works... but it's confusing.  You can ignore my first commit.

## Testing this PR
1. Add some QR Codes
2. Go to the index view.
3. Click the row, it should navigate to the edit page.
4. CRUD Codes and test nothing is broken due to the Polaris upgrade

## TODO

- [ ] Update template with the new Link implementation.

