### PR TITLE
refactor: add index files and routes to pages

### DIFF
--- a/qr-code/node/web/frontend/components/CodeEditForm.jsx
+++ b/qr-code/node/web/frontend/components/CodeEditForm.jsx
@@ -20,13 +20,11 @@ import {
   useAppBridge,
 } from '@shopify/app-bridge-react'
 import { ImageMajor, AlertMinor } from '@shopify/polaris-icons'
-import { useShopifyQuery } from '../hooks/useShopifyQuery'
+import { useShopifyQuery, useAuthenticatedFetch, useNavigate } from '../hooks'
 import { gql } from 'graphql-request'
 import { useForm, useField, notEmptyString } from '@shopify/react-form'
 
-import { useAuthenticatedFetch } from '../hooks/useAuthenticatedFetch'
 import { productCheckoutURL, productViewURL } from '../helpers/product-urls'
-import { useNavigate } from '../hooks/location-with-state.js'
 
 const NO_DISCOUNT_OPTION = { label: 'No discount', value: '' }
 

--- a/qr-code/node/web/frontend/hooks/index.js
+++ b/qr-code/node/web/frontend/hooks/index.js
@@ -1,0 +1,4 @@
+export {useAuthenticatedFetch} from './useAuthenticatedFetch'
+export {useShopifyMutation} from './useShopifyMutation'
+export {useShopifyQuery} from './useShopifyQuery'
+export * from './location-with-state'

--- a/qr-code/node/web/frontend/hooks/useShopifyMutation.js
+++ b/qr-code/node/web/frontend/hooks/useShopifyMutation.js
@@ -1,7 +1,7 @@
 import { useMutation } from 'react-query'
 import { GraphQLClient } from 'graphql-request'
 
-import { useAuthenticatedFetch } from './useAuthenticatedFetch.js'
+import { useAuthenticatedFetch } from './'
 
 /**
  * A hook for mutating admin data.

--- a/qr-code/node/web/frontend/hooks/useShopifyQuery.js
+++ b/qr-code/node/web/frontend/hooks/useShopifyQuery.js
@@ -1,7 +1,7 @@
 import { useQuery } from 'react-query'
 import { GraphQLClient } from 'graphql-request'
 
-import { useAuthenticatedFetch } from './useAuthenticatedFetch.js'
+import { useAuthenticatedFetch } from './'
 
 /**
  * A hook for querying admin data.

--- a/qr-code/node/web/frontend/pages/codes/edit/[id].jsx
+++ b/qr-code/node/web/frontend/pages/codes/edit/[id].jsx
@@ -10,10 +10,9 @@ import {
   TextContainer,
 } from '@shopify/polaris'
 
-import { CodeEditForm } from '../../../components/CodeEditForm'
-import { useAuthenticatedFetch } from '../../../hooks/useAuthenticatedFetch'
+import { CodeEditForm } from '../../../components'
+import { useAuthenticatedFetch, useLocation } from '../../../hooks'
 import { TitleBar } from '@shopify/app-bridge-react'
-import { useLocation } from '../../../hooks/location-with-state'
 
 export default function CodeEdit() {
   const { state } = useLocation()

--- a/qr-code/node/web/frontend/pages/index.jsx
+++ b/qr-code/node/web/frontend/pages/index.jsx
@@ -1,10 +1,8 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, TitleBar } from '@shopify/app-bridge-react'
 import { Card, EmptyState, Layout, Page } from '@shopify/polaris'
-
-import { useAuthenticatedFetch } from '../hooks/useAuthenticatedFetch'
-
-import { CodeIndex } from '../components/CodeIndex'
+import { useAuthenticatedFetch } from '../hooks'
+import { CodeIndex } from '../components'
 
 export default function HomePage() {
   const navigate = useNavigate()


### PR DESCRIPTION
Closes: https://github.com/Shopify/first-party-library-planning/issues/247
Background:
Not being able to important components or hooks together can add confusion

Solution:
Added separate index files for hooks and components to import them easier.