### PR TITLE
Rename code to qrcode

### DIFF
--- a/qr-code/node/web/frontend/components/QRCodeEditForm.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeEditForm.jsx
@@ -71,7 +71,7 @@ const DISCOUNTS_QUERY = gql`
 
 const DISCOUNT_CODES = {}
 
-export function CodeEditForm({ QRCode, setQRCode }) {
+export function QRCodeEditForm({ QRCode, setQRCode }) {
   const [showResourcePicker, setShowResourcePicker] = useState(false)
   const [selectedProduct, setSelectedProduct] = useState(QRCode?.product)
   const navigate = useNavigate()
@@ -98,7 +98,7 @@ export function CodeEditForm({ QRCode, setQRCode }) {
           const QRCode = await response.json()
           // If there is no codeId, this is a new QR Code being saved.
           if (!codeId) {
-            navigate(`/codes/edit/${QRCode.id}`, { state: QRCode })
+            navigate(`/qrcodes/edit/${QRCode.id}`, { state: QRCode })
           } else {
             setQRCode(QRCode)
           }

--- a/qr-code/node/web/frontend/components/QRCodeIndex.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeIndex.jsx
@@ -3,21 +3,21 @@ import { Card, IndexTable, Thumbnail, UnstyledLink } from '@shopify/polaris'
 import { ShopcodesMajor } from '@shopify/polaris-icons'
 import dayjs from 'dayjs'
 
-export function CodeIndex({ qrCodes }) {
+export function QRCodeIndex({ QRCodes }) {
   const navigate = useNavigate()
   const resourceName = {
     singular: 'code',
     plural: 'codes',
   }
 
-  const rowMarkup =  qrCodes.map(
+  const rowMarkup =  QRCodes.map(
     ({ id, title, product, discountCode, scans, createdAt }, index) => (
       <IndexTable.Row
         id={id}
         key={id}
         position={index}
         onClick={() => {
-          navigate(`/codes/edit/${id}`)
+          navigate(`/qrcodes/edit/${id}`)
         }}
       >
         <IndexTable.Cell>
@@ -28,7 +28,7 @@ export function CodeIndex({ qrCodes }) {
           />
         </IndexTable.Cell>
         <IndexTable.Cell>
-          <UnstyledLink data-primary-link url={`/codes/edit/${id}`}>
+          <UnstyledLink data-primary-link url={`/qrcodes/edit/${id}`}>
             {title}
           </UnstyledLink>
         </IndexTable.Cell>
@@ -46,7 +46,7 @@ export function CodeIndex({ qrCodes }) {
     <Card>
       <IndexTable
         resourceName={resourceName}
-        itemCount={qrCodes.length}
+        itemCount={QRCodes.length}
         headings={[
           { title: 'Thumbnail', hidden: true },
           { title: 'Title' },

--- a/qr-code/node/web/frontend/components/index.js
+++ b/qr-code/node/web/frontend/components/index.js
@@ -1,3 +1,3 @@
-export { CodeEditForm } from './CodeEditForm'
-export { CodeIndex } from './CodeIndex'
+export { QRCodeEditForm } from './QRCodeEditForm'
+export { QRCodeIndex } from './QRCodeIndex'
 export * from './providers'

--- a/qr-code/node/web/frontend/pages/index.jsx
+++ b/qr-code/node/web/frontend/pages/index.jsx
@@ -1,20 +1,26 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, TitleBar, Loading } from '@shopify/app-bridge-react'
-import { Card, EmptyState, Layout, Page, SkeletonBodyText } from '@shopify/polaris'
+import {
+  Card,
+  EmptyState,
+  Layout,
+  Page,
+  SkeletonBodyText,
+} from '@shopify/polaris'
 import { useAuthenticatedFetch } from '../hooks'
-import { CodeIndex } from '../components'
+import { QRCodeIndex } from '../components'
 
 export default function HomePage() {
   const navigate = useNavigate()
   const fetch = useAuthenticatedFetch()
-  const [{ loading, qrCodes }, setData] = useState({
+  const [{ loading, QRCodes }, setData] = useState({
     loading: true,
-    qrCodes: [],
+    QRCodes: [],
   })
 
   useEffect(async () => {
-    const qrCodes = await fetch('/api/qrcodes').then((res) => res.json())
-    setData({ loading: false, qrCodes })
+    const QRCodes = await fetch('/api/qrcodes').then((res) => res.json())
+    setData({ loading: false, QRCodes })
   }, [])
 
   const loadingMarkup = loading ? (
@@ -24,17 +30,17 @@ export default function HomePage() {
     </Card>
   ) : null
 
-  const qrCodesMarkup =
-    qrCodes.length && !loading ? <CodeIndex qrCodes={qrCodes} /> : null
+  const QRCodesMarkup =
+    QRCodes.length && !loading ? <QRCodeIndex QRCodes={QRCodes} /> : null
 
   const emptyStateMarkup =
-    !loading && !qrCodes.length ? (
+    !loading && !QRCodes.length ? (
       <Card sectioned>
         <EmptyState
           heading="Create unique QR codes for your product"
           action={{
             content: 'Create QR code',
-            onAction: () => navigate('/codes'),
+            onAction: () => navigate('/qrcodes'),
           }}
           image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
         >
@@ -50,13 +56,13 @@ export default function HomePage() {
       <TitleBar
         primaryAction={{
           content: 'Create QR code',
-          onAction: () => navigate('/codes'),
+          onAction: () => navigate('/qrcodes'),
         }}
       />
       <Layout>
         <Layout.Section>
           {loadingMarkup}
-          {qrCodesMarkup}
+          {QRCodesMarkup}
           {emptyStateMarkup}
         </Layout.Section>
       </Layout>

--- a/qr-code/node/web/frontend/pages/qrcodes/edit/[id].jsx
+++ b/qr-code/node/web/frontend/pages/qrcodes/edit/[id].jsx
@@ -10,7 +10,7 @@ import {
   TextContainer,
 } from '@shopify/polaris'
 
-import { CodeEditForm } from '../../../components'
+import { QRCodeEditForm } from '../../../components'
 import { useAuthenticatedFetch, useLocation } from '../../../hooks'
 import { TitleBar } from '@shopify/app-bridge-react'
 
@@ -69,7 +69,7 @@ export default function CodeEdit() {
   return (
     <Page>
       <TitleBar title="Edit QR code" primaryAction={null} />
-      <CodeEditForm {...{ QRCode, setQRCode }} />
+      <QRCodeEditForm {...{ QRCode, setQRCode }} />
     </Page>
   )
 }

--- a/qr-code/node/web/frontend/pages/qrcodes/index.jsx
+++ b/qr-code/node/web/frontend/pages/qrcodes/index.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Card, Page, Layout, Button, EmptyState } from '@shopify/polaris'
 import { TitleBar } from '@shopify/app-bridge-react'
 
-import { CodeEditForm } from '../../components/CodeEditForm'
+import { QRCodeEditForm } from '../../components'
 
 export default function ManageCode() {
   const [QRCode, setQRCode] = useState()
@@ -10,7 +10,7 @@ export default function ManageCode() {
   return (
     <Page>
       <TitleBar title="Create new QR code" primaryAction={null} />
-      <CodeEditForm QRCode={QRCode} setQRCode={setQRCode} />
+      <QRCodeEditForm QRCode={QRCode} setQRCode={setQRCode} />
     </Page>
   )
 }


### PR DESCRIPTION
closes: [#284](https://github.com/Shopify/first-party-library-planning/issues/284)

 - Renames the frontend route to /qrcodes/ (to match backend /api/qrcodes/).
 - Renames CodeIndex to QRCodeIndex.
 - Rename CodeEditForm to QRCodeEditForm`.

The ` Rename New code page title to New QR code.` task had already been done, so it is not in this PR. 
<img width="660" alt="Screen Shot 2022-06-01 at 3 21 04 PM" src="https://user-images.githubusercontent.com/78764587/171503957-c1789a85-b808-442b-9914-7ec0cbb3e26d.png">


**Note** This was branched off of Richards branch for the loading state to not have merging issues