### PR TITLE
fix: add fallback product handle when creating URL

### DIFF
--- a/qr-code/node/web/frontend/components/QRCodeEditForm.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeEditForm.jsx
@@ -196,10 +196,11 @@ export function QRCodeEditForm({ QRCode, setQRCode }) {
     if (!selectedProduct) return
     const data = {
       host: appBridge.hostOrigin,
-      productHandle: handle.value,
+      productHandle: handle.value || selectedProduct.handle,
       discountCount: discountCode.value || undefined,
       variantId: variantId.value,
     }
+
     const targetURL =
       destination.value[0] === 'product'
         ? productViewURL(data)

--- a/qr-code/node/web/frontend/pages/qrcodes/index.jsx
+++ b/qr-code/node/web/frontend/pages/qrcodes/index.jsx
@@ -1,16 +1,13 @@
-import { useState } from 'react'
-import { Card, Page, Layout, Button, EmptyState } from '@shopify/polaris'
+import { Page } from '@shopify/polaris'
 import { TitleBar } from '@shopify/app-bridge-react'
 
 import { QRCodeEditForm } from '../../components'
 
 export default function ManageCode() {
-  const [QRCode, setQRCode] = useState()
-
   return (
     <Page>
       <TitleBar title="Create new QR code" primaryAction={null} />
-      <QRCodeEditForm QRCode={QRCode} setQRCode={setQRCode} />
+      <QRCodeEditForm />
     </Page>
   )
 }


### PR DESCRIPTION
## Background

Closes https://github.com/Shopify/first-party-library-planning/issues/300

When creating a new QR code, the preview destination dis not work before selecting a destination because the product handle was not getting populated.

## Solution

Add a fallback to use the product handle that we were already storing in state when a product gets selected/

### Unrelated cleanup:

In the `ManageCode` component, we were passing in a `QRCode` and setter although we did not ever have a `QRCode` in the this view. We removed this.

Paired with @hheyhhay  