### PR TITLE
fix: Update image paths in form

### DIFF
--- a/qr-code/node/web/frontend/components/QRCodeForm.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeForm.jsx
@@ -232,6 +232,10 @@ export function QRCodeForm({ QRCode, setQRCode }) {
       ]
     : []
 
+  const imageSrc = selectedProduct?.images?.edges?.[0]?.node?.url
+  const originalImageSrc = selectedProduct?.images?.[0]?.originalSrc
+  const altText = selectedProduct?.images?.[0]?.altText || selectedProduct?.title
+
   return (
     <Layout>
       <Layout.Section>
@@ -286,10 +290,10 @@ export function QRCodeForm({ QRCode, setQRCode }) {
                 )}
                 {productId.value ? (
                   <Stack alignment="center">
-                    {selectedProduct.images[0] ? (
+                    {(imageSrc || originalImageSrc) ? (
                       <Thumbnail
-                        source={selectedProduct.images[0].originalSrc}
-                        alt={selectedProduct.images[0].altText}
+                        source={imageSrc || originalImageSrc}
+                        alt={altText}
                       />
                     ) : (
                       <Icon source={ImageMajor} color="base" />


### PR DESCRIPTION
## Background

Closes https://github.com/Shopify/first-party-library-planning/issues/304

Icon placeholder would always appear even if the product had an image. The path to check for the image was incorrect.

## Solution 

Fix path to check for image.

![Screen Shot 2022-06-02 at 11 13 11 AM](https://user-images.githubusercontent.com/7654369/171686384-cb1657eb-5315-43fa-b3a9-aec4304628d3.png)
