### PR TITLE
fix: update discounts

### DIFF
--- a/qr-code/node/web/frontend/components/QRCodeForm.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeForm.jsx
@@ -201,10 +201,11 @@ export function QRCodeForm({ QRCode, setQRCode }) {
 
   const goToDestination = useCallback(() => {
     if (!selectedProduct) return
+
     const data = {
       host: appBridge.hostOrigin,
-      productHandle: handle.value || selectedProduct.handle,
-      discountCount: discountCode.value || undefined,
+      productHandle: handle.value,
+      discountCode: discountCode.value,
       variantId: variantId.value,
     }
 
@@ -214,7 +215,7 @@ export function QRCodeForm({ QRCode, setQRCode }) {
         : productCheckoutURL(data)
 
     window.open(targetURL, '_blank', 'noreferrer,noopener')
-  }, [QRCode, selectedProduct, destination])
+  }, [appBridge.hostOrigin, handle.value, destination.value, variantId.value, discountCode.value, selectedProduct])
 
   const discountOptions = discounts
     ? [

--- a/qr-code/node/web/frontend/helpers/product-urls.js
+++ b/qr-code/node/web/frontend/helpers/product-urls.js
@@ -26,9 +26,7 @@ export function productCheckoutURL({
 
   url.pathname = `/cart/${id}:${quantity}`
 
-  if (discountCode) {
-    url.searchParams.append('discount', discountCode)
-  }
+  url.searchParams.append('discount', discountCode)
 
   return url.toString()
 }


### PR DESCRIPTION
### What?

The issue described in https://github.com/Shopify/first-party-library-planning/issues/309 was actually caused by the existence of an automatic discount that was applied first, regardless of which discount code was selected in the app.  Essentially, if an automatic discount exists, it will be the only discount applied. ~This is not something we can address with our code and is probably something that we should call out in the documentation.~

**Update**: The automatic discount was masking another issue - selecting _no discount_ was not overriding the previous discount. We were only updating the search params _if there was a discount selected_, which makes UX sense - we don't want to display a URL to the user with an empty param like `discounts=`. That said, when we don't reset the discounts param, the checkout page seems to hold on to the last discount.  

**The fix**: By removing the condition that only sets the discount param if it exists, we now set the discount param every time "Go to destination" is clicked. Our `targetUrl` now includes `discount=` every time it is generated. This would be a weird UX if this was the final destination that the user lands on, but because we immediately redirect from the cart URL where we attach the param, to the checkout URL that uses the param, this is not an issue.

https://user-images.githubusercontent.com/7654369/171918653-421ddf79-e2e5-4a6a-a2b0-7c6b4c38da7b.mov

### Why?

Closes https://github.com/Shopify/first-party-library-planning/issues/309

### How?

While investigating this problem, we identified a couple other issues with the function that creates the "go to destination" link. There was a misnamed key and some missing dependencies. This PR addresses those issues. 

### Checklist

- [ ] Run the app
- [ ] Ensure that you don't have any automatic discounts that apply to all products
- [ ] Click on "Create QR code"
- [ ] Add a title, select a product, select checkout page destination, and change the discount code option
- [ ] Click on "Go to destination"
- [ ] Confirm that the expected discount is applied

![Screen Shot 2022-06-03 at 9 44 18 AM](https://user-images.githubusercontent.com/7654369/171899912-413305d8-1200-4db0-b3bf-63454ffb651f.png)
![Screen Shot 2022-06-03 at 9 44 27 AM](https://user-images.githubusercontent.com/7654369/171899947-450e294e-c781-4867-ab80-b87ae9a06153.png)


#### Before Merging

- [x] I have 🎩'd this locally
  - [x] If this is complex to 🎩, I have provided instructions for others
- [x] I have requested reviews or pinged the relevant persons/teams

