### PR TITLE
change icon to thumbnail and update image to be same

### DIFF
--- a/qr-code/node/web/frontend/components/QRCodeForm.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeForm.jsx
@@ -296,7 +296,7 @@ export function QRCodeForm({ QRCode, setQRCode }) {
                         alt={altText}
                       />
                     ) : (
-                      <Icon source={ImageMajor} color="base" />
+                      <Thumbnail source={ImageMajor} color="base" size="small" />
                     )}
                     <TextStyle variation="strong">
                       {selectedProduct.title}

--- a/qr-code/node/web/frontend/components/QRCodeIndex.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeIndex.jsx
@@ -1,6 +1,6 @@
 import { useNavigate } from '@shopify/app-bridge-react'
 import { Card, IndexTable, Thumbnail, UnstyledLink } from '@shopify/polaris'
-import { ShopcodesMajor } from '@shopify/polaris-icons'
+import { ImageMajor } from '@shopify/polaris-icons'
 import dayjs from 'dayjs'
 
 export function QRCodeIndex({ QRCodes }) {
@@ -22,8 +22,9 @@ export function QRCodeIndex({ QRCodes }) {
       >
         <IndexTable.Cell>
           <Thumbnail
-            source={product?.images?.edges[0]?.node?.url || ShopcodesMajor}
+            source={product?.images?.edges[0]?.node?.url || ImageMajor}
             alt="placeholder"
+            color="base"
             size="small"
           />
         </IndexTable.Cell>


### PR DESCRIPTION
### What?
closes: #312

Update the no product images to match


### Why?

For consistency in application and to match product table

### How?

- Changed QRCodeForm `Icon` to be a thumbnail for size consistency
- Changed QRCodeIndex from `ShopCodesMajor` to `ImageMajor`
Updated Images : 

<img width="514" alt="Screen Shot 2022-06-03 at 9 49 28 AM" src="https://user-images.githubusercontent.com/78764587/171900788-a93929f6-e94a-45a6-a76c-9941197d6234.png">
<img width="429" alt="Screen Shot 2022-06-03 at 9 49 43 AM" src="https://user-images.githubusercontent.com/78764587/171900792-a90cccf7-e0d6-4ded-9d90-a4f7e4396937.png">


### Checklist

#### Before Merging

- [X] I have 🎩'd this locally
  - [ ] If this is complex to 🎩, I have provided instructions for others
- [X

] I have requested reviews or pinged the relevant persons/teams

