### PR TITLE
fix: reset form before deleting QR code

### DIFF
--- a/qr-code/node/web/frontend/components/QRCodeForm.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeForm.jsx
@@ -189,6 +189,7 @@ export function QRCodeForm({ QRCode: InitialQRCode }) {
 
   const [isDeleting, setIsDeleting] = useState(false)
   const deleteQRCode = useCallback(async () => {
+    reset()
     setIsDeleting(true)
     const response = await fetch(`/api/qrcodes/${QRCode.id}`, {
       method: 'DELETE',


### PR DESCRIPTION
## Background

When deleting the QR code, if the edit form was in a dirty state, the contextual save bar remained open and caused prevent "confirm navigation" modal to pop up (but it navigated anyway - an unrelated bug in App Bridge that is addressed [here](https://github.com/Shopify/app-bridge/pull/2426)). 

### Before

https://user-images.githubusercontent.com/7654369/172187100-da9f4da0-654b-4197-9f88-4f67d6f2c661.mov


## Solution

Reset the form before navigating when the QR code gets deleted.

### After

https://user-images.githubusercontent.com/7654369/172187719-1ff060e5-728f-46ef-a26c-fb4dd5e24aa3.mov


## Testing this PR

- [ ] Create a new QR code
- [ ] Change something in the edit form
- [ ] Click"Delete QR code" button
- [ ] You should navigate to the index without any warnings or errors