### PR TITLE
fix: add download functionality

### DIFF
--- a/qr-code/node/web/frontend/components/QRCodeForm.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeForm.jsx
@@ -233,6 +233,11 @@ export function QRCodeForm({ QRCode: InitialQRCode }) {
       ]
     : []
 
+  const QRCodeURL = new URL(
+    `/qrcodes/${QRCode.id}/image`,
+    location.toString()
+  ).toString()
+
   const imageSrc = selectedProduct?.images?.edges?.[0]?.node?.url
   const originalImageSrc = selectedProduct?.images?.[0]?.originalSrc
   const altText = selectedProduct?.images?.[0]?.altText || selectedProduct?.title
@@ -381,10 +386,7 @@ export function QRCodeForm({ QRCode: InitialQRCode }) {
           {QRCode ? (
             <EmptyState
               imageContained={true}
-              largeImage={new URL(
-                `/qrcodes/${QRCode.id}/image`,
-                location.toString()
-              ).toString()}
+              largeImage={QRCodeURL}
             />
           ) : (
             <EmptyState>
@@ -392,7 +394,7 @@ export function QRCodeForm({ QRCode: InitialQRCode }) {
             </EmptyState>
           )}
           <Stack vertical>
-            <Button fullWidth primary disabled={!QRCode || isDeleting}>
+            <Button fullWidth primary download url={QRCodeURL} disabled={!QRCode || isDeleting}>
               Download
             </Button>
             <Button


### PR DESCRIPTION
## Background

Download button stopped working at some point.

## Solution

Re-connect download functionality

https://user-images.githubusercontent.com/7654369/172199621-34f8d1db-2e80-46f2-84cc-9b90c691ce20.mov

## Testing this PR

- Go to a saved QR code
- Click "Download" button
- Confirm that QR code downloads 
