### PR TITLE
fix: only create QRCode link if it already exists

### DIFF
--- a/qr-code/node/web/frontend/components/QRCodeForm.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeForm.jsx
@@ -234,10 +234,10 @@ export function QRCodeForm({ QRCode: InitialQRCode }) {
       ]
     : []
 
-  const QRCodeURL = new URL(
+  const QRCodeURL = QRCode ? new URL(
     `/qrcodes/${QRCode.id}/image`,
     location.toString()
-  ).toString()
+  ).toString() : null
 
   const imageSrc = selectedProduct?.images?.edges?.[0]?.node?.url
   const originalImageSrc = selectedProduct?.images?.[0]?.originalSrc


### PR DESCRIPTION
Follow up to https://github.com/Shopify/shopify-app-examples/pull/81

I created a variable to store the `QRCodeURL` because it is now used in 2 places. However the `QRCode` object does not exist before the QR code is saved once. This PR conditionally creates the URL if the QR code exists. 

 