### PR TITLE
chore: turn off refetchOnWindowFocus option

### DIFF
--- a/qr-code/node/web/frontend/hooks/useAppQuery.js
+++ b/qr-code/node/web/frontend/hooks/useAppQuery.js
@@ -17,11 +17,14 @@ import { useAuthenticatedFetch } from './'
 export const useAppQuery = ({ url, fetchInit = {}, reactQueryOptions }) => {
   const authenticatedFetch = useAuthenticatedFetch()
   const fetch = useMemo(() => {
-    return async () =>  {
+    return async () => {
       const response = await authenticatedFetch(url, fetchInit)
       return response.json()
     }
   }, [url, JSON.stringify(fetchInit)])
 
-  return useQuery(url, fetch, reactQueryOptions)
+  return useQuery(url, fetch, {
+    ...reactQueryOptions,
+    refetchOnWindowFocus: false,
+  })
 }


### PR DESCRIPTION
## Background

Closes https://github.com/Shopify/first-party-library-planning/issues/315

We had a feature turned on to refetch data when a user focuses in a window, but we decided that we don't need this functionality. 

### Before

https://user-images.githubusercontent.com/7654369/172218770-54e83850-9d1a-431d-badf-04ad288bf6ac.mov

### After

I tried to record an "after" video, but _nothing_ happens in the UI. 😂 

### Testing this PR

- [ ] Load the app (with some saved QR codes)
- [ ] On the index page, click anywhere on the page
- [ ] You should not see the blue loading indicator in the index table
