### PR TITLE
chore: handle deleted product gracefully

### DIFF
--- a/qr-code/node/web/frontend/components/QRCodeForm.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeForm.jsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react'
 import {
+  Banner,
   Card,
   Form,
   FormLayout,
@@ -79,6 +80,7 @@ export function QRCodeForm({ QRCode: InitialQRCode }) {
   const navigate = useNavigate()
   const appBridge = useAppBridge()
   const fetch = useAuthenticatedFetch()
+  const deletedProduct = QRCode?.product?.title === 'Deleted product'
 
   const onSubmit = useCallback(
     (body) => {
@@ -137,7 +139,7 @@ export function QRCodeForm({ QRCode: InitialQRCode }) {
         validates: [notEmptyString('Please name your QR code')],
       }),
       productId: useField({
-        value: QRCode?.product?.id || '',
+        value: deletedProduct ? 'Deleted product' : (QRCode?.product?.id || ''),
         validates: [notEmptyString('Please select a product')],
       }),
       variantId: useField(QRCode?.variantId || ''),
@@ -210,10 +212,9 @@ export function QRCodeForm({ QRCode: InitialQRCode }) {
       variantId: variantId.value,
     }
 
-    const targetURL =
-      destination.value[0] === 'product'
-        ? productViewURL(data)
-        : productCheckoutURL(data)
+    const targetURL = deletedProduct || destination.value[0] === 'product'
+      ? productViewURL(data)
+      : productCheckoutURL(data)
 
     window.open(targetURL, '_blank', 'noreferrer,noopener')
   }, [QRCode, selectedProduct, destination, discountCode, handle, variantId])
@@ -244,7 +245,16 @@ export function QRCodeForm({ QRCode: InitialQRCode }) {
   const altText = selectedProduct?.images?.[0]?.altText || selectedProduct?.title
 
   return (
-    <Layout>
+    <Stack vertical>
+      {deletedProduct && <Banner
+        title="The product for this QR code no longer exists."
+        status="critical"
+      >
+        <p>
+          Scans will be directed to a 404 page, or you can choose another product for this QR code.
+        </p>
+      </Banner>}
+      <Layout>
       <Layout.Section>
         <Form>
           <ContextualSaveBar
@@ -398,16 +408,17 @@ export function QRCodeForm({ QRCode: InitialQRCode }) {
             <Button fullWidth primary download url={QRCodeURL} disabled={!QRCode || isDeleting}>
               Download
             </Button>
-            <Button
-              fullWidth
-              onClick={goToDestination}
-              disabled={!selectedProduct}
-            >
-              Go to destination
-            </Button>
-          </Stack>
-        </Card>
-      </Layout.Section>
-    </Layout>
+              <Button
+                fullWidth
+                onClick={goToDestination}
+                disabled={!selectedProduct}
+              >
+                Go to destination
+              </Button>
+            </Stack>
+          </Card>
+        </Layout.Section>
+      </Layout>
+    </Stack>
   )
 }

--- a/qr-code/node/web/frontend/components/QRCodeIndex.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeIndex.jsx
@@ -1,6 +1,6 @@
 import { useNavigate } from '@shopify/app-bridge-react'
-import { Card, IndexTable, Thumbnail, UnstyledLink } from '@shopify/polaris'
-import { ImageMajor } from '@shopify/polaris-icons'
+import { Card, Icon, IndexTable, Stack, TextStyle, Thumbnail, UnstyledLink } from '@shopify/polaris'
+import { DiamondAlertMajor, ImageMajor } from '@shopify/polaris-icons'
 import dayjs from 'dayjs'
 
 export function QRCodeIndex({ QRCodes, loading }) {
@@ -11,36 +11,47 @@ export function QRCodeIndex({ QRCodes, loading }) {
   }
 
   const rowMarkup = QRCodes.map(
-    ({ id, title, product, discountCode, scans, createdAt }, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        position={index}
-        onClick={() => {
-          navigate(`/qrcodes/${id}`)
-        }}
-      >
-        <IndexTable.Cell>
-          <Thumbnail
-            source={product?.images?.edges[0]?.node?.url || ImageMajor}
-            alt="placeholder"
-            color="base"
-            size="small"
-          />
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <UnstyledLink data-primary-link url={`/qrcodes/${id}`}>
-            {title}
-          </UnstyledLink>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{product.title}</IndexTable.Cell>
-        <IndexTable.Cell>{discountCode}</IndexTable.Cell>
-        <IndexTable.Cell>
-          {dayjs(createdAt).format('MMMM D, YYYY')}
-        </IndexTable.Cell>
-        <IndexTable.Cell>{scans}</IndexTable.Cell>
-      </IndexTable.Row>
-    )
+    ({ id, title, product, discountCode, scans, createdAt }, index) => {
+      const deletedProduct = product.title.includes('Deleted product')
+
+      return (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          position={index}
+          onClick={() => {
+            navigate(`/qrcodes/${id}`)
+          }}
+        >
+          <IndexTable.Cell>
+            <Thumbnail
+              source={product?.images?.edges[0]?.node?.url || ImageMajor}
+              alt="placeholder"
+              color="base"
+              size="small"
+            />
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <UnstyledLink data-primary-link url={`/qrcodes/${id}`}>
+              {title}
+            </UnstyledLink>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Stack>
+              {deletedProduct && <Icon source={DiamondAlertMajor} color="critical" />}
+              <TextStyle variation={deletedProduct ? "negative" : null}>
+                {product.title}
+              </TextStyle>
+            </Stack>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{discountCode}</IndexTable.Cell>
+          <IndexTable.Cell>
+            {dayjs(createdAt).format('MMMM D, YYYY')}
+          </IndexTable.Cell>
+          <IndexTable.Cell>{scans}</IndexTable.Cell>
+        </IndexTable.Row>
+      )
+    }
   )
 
   return (

--- a/qr-code/node/web/helpers/qr-codes.js
+++ b/qr-code/node/web/helpers/qr-codes.js
@@ -96,8 +96,10 @@ export async function formatQrCodeResponse(req, res, rawCodeData) {
 
   const formattedData = rawCodeData.map((qrCode) => {
     const product = adminData.body.data.nodes.find(
-      (node) => qrCode.productId == node.id
-    );
+      (node) => qrCode.productId === node?.id
+    ) || {
+      title: "Deleted product",
+    };
 
     const formattedQRCode = { ...qrCode, product };
 

--- a/qr-code/node/web/middleware/qr-code-public.js
+++ b/qr-code/node/web/middleware/qr-code-public.js
@@ -1,4 +1,3 @@
-import path from "path";
 import QRCode from "qrcode";
 
 import { QRCodesDB } from "../qr-codes-db.js";


### PR DESCRIPTION
## Background

Related to https://github.com/Shopify/first-party-library-planning/issues/321

If a product gets deleted after a QR code is created, the QR code is invalid, but we should handle the missing product gracefully.

## Solution

On the index page, if a product is missing, we display 'DELETED PRODUCT' in place of the product name.
![Screen Shot 2022-06-07 at 1 57 53 PM](https://user-images.githubusercontent.com/7654369/172472136-1d276917-bee7-4ae6-b4cb-0acf28492335.png)

On the detail/edit page, if the product is missing, we display a critical banner.
![Screen Shot 2022-06-07 at 1 57 37 PM](https://user-images.githubusercontent.com/7654369/172472162-31dc57ee-d5ec-4abc-b08e-1fa4469c2c22.png)


## Partially completed in this PR

If the product is deleted, the QR code destination should be the home page (or the product page as it is currently implemented). Updating this on the front end ('Go to destination' link) is done here. We should also update the QR code destination if the product is missing, but this is a bit trickier since we cannot access the Admin API when the QR code is scanned since it's a public endpoint without access to the JWT. Discussing with @paulomarg , we think that it would be worth implementing a webhook to update the QRCodes DB when a product is deleted. Alternatively, if we don't have time for this, we can allow the deleted products to go to a 404 page. @SeanyB 

## Need more feedback...

...on the styles. 😄 @RileyMacIntosh 

