### PR TITLE
fix: remove largeImage and replace with image to keep size the same o…

### DIFF
--- a/qr-code/node/web/frontend/components/QRCodeForm.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeForm.jsx
@@ -387,7 +387,7 @@ export function QRCodeForm({ QRCode: InitialQRCode }) {
           {QRCode ? (
             <EmptyState
               imageContained={true}
-              largeImage={QRCodeURL}
+              image={QRCodeURL}
             />
           ) : (
             <EmptyState>


### PR DESCRIPTION
Closes: [#334](https://github.com/Shopify/first-party-library-planning/issues/334)

Solution:
Remove largeImage and replace with image attribute on EmptyState

https://user-images.githubusercontent.com/78764587/172486911-ff859612-de16-414b-8c71-eabb4306a4b5.mov



