### PR TITLE
chore: handle deleted discounts gracefully

### DIFF
--- a/qr-code/node/web/helpers/qr-codes.js
+++ b/qr-code/node/web/helpers/qr-codes.js
@@ -20,6 +20,9 @@ const QR_CODE_ADMIN_QUERY = `
       ... on ProductVariant {
         id
       }
+      ... on DiscountCodeNode {
+        id
+      }
     }
   }
 `;
@@ -101,7 +104,23 @@ export async function formatQrCodeResponse(req, res, rawCodeData) {
       title: "Deleted product",
     };
 
-    const formattedQRCode = { ...qrCode, product };
+    const discountDeleted =
+      qrCode.discountId &&
+      !adminData.body.data.nodes.find((node) => qrCode.discountId === node?.id);
+
+    if (discountDeleted) {
+      QRCodesDB.update(qrCode.id, {
+        ...qrCode,
+        discountId: "",
+        discountCode: "",
+      });
+    }
+
+    const formattedQRCode = {
+      ...qrCode,
+      product,
+      discountCode: discountDeleted ? "" : qrCode.discountCode,
+    };
 
     delete formattedQRCode.productId;
 


### PR DESCRIPTION
## Background

Closes https://github.com/Shopify/first-party-library-planning/issues/319

When discounts that were associated with QR codes were deleted, the index page still displayed the discount code.

## Solution

Before returning QR code data, the backend checks if the `discountId` on the `qrCode` exists in the Admin. If it doesn't, it sets the `discountCode` to an empty string before returning it to the frontend.

## Testing this PR

- Run the app
- Create a QR code with a discount
- In a separate tab, delete the discount associated with the QR code that you just created
- Visit the index
- The QR code should look normal, but not display a discount code
- Visit the edit page
- The discounts dropdown should be set to "No discount"