### PR TITLE
Copy in template changes needed for pnpm support

### DIFF
--- a/qr-code/node/.npmrc
+++ b/qr-code/node/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 auto-install-peers=true
+shamefully-hoist=true

--- a/qr-code/node/web/frontend/vite.config.js
+++ b/qr-code/node/web/frontend/vite.config.js
@@ -23,6 +23,9 @@ export default defineConfig({
   esbuild: {
     jsxInject: `import React from 'react'`,
   },
+  resolve: {
+    preserveSymlinks: true,
+  },
   server: {
     port: process.env.FRONTEND_PORT,
     middlewareMode: 'html',


### PR DESCRIPTION
Copying in the changes made to the node backend template and the react frontend template need for `pnpm` support.

PRs in template repos that are sources for these changes
- https://github.com/Shopify/shopify-frontend-template-react/pull/71/files
- https://github.com/Shopify/shopify-app-template-node/pull/850/files