### PR TITLE
fix: add breadcrumbs to new QR code and edit QR code form.

### DIFF
--- a/qr-code/node/web/frontend/pages/index.jsx
+++ b/qr-code/node/web/frontend/pages/index.jsx
@@ -51,6 +51,7 @@ export default function HomePage() {
   return (
     <Page>
       <TitleBar
+        title='QR codes'
         primaryAction={{
           content: 'Create QR code',
           onAction: () => navigate('/qrcodes/new'),

--- a/qr-code/node/web/frontend/pages/qrcodes/[id].jsx
+++ b/qr-code/node/web/frontend/pages/qrcodes/[id].jsx
@@ -1,7 +1,6 @@
 import { useParams } from 'react-router-dom'
 import { Card, Page, Layout, SkeletonBodyText } from '@shopify/polaris'
 import { Loading, TitleBar } from '@shopify/app-bridge-react'
-
 import { useAppQuery } from '../../hooks'
 import { QRCodeForm } from '../../components'
 
@@ -19,12 +18,12 @@ export default function QRCodeEdit() {
     },
   })
 
-  const titleBarMarkup = <TitleBar title="Edit QR code" primaryAction={null} />
+  const breadcrumbs = [{content: 'QR codes', url: '/' }]
 
   if (isLoading || isRefetching) {
     return (
       <Page>
-        {titleBarMarkup}
+        <TitleBar title="Edit QR code" breadcrumbs={breadcrumbs} primaryAction={null} />
         <Loading />
         <Layout>
           <Layout.Section>
@@ -53,7 +52,7 @@ export default function QRCodeEdit() {
 
   return (
     <Page>
-      {titleBarMarkup}
+      <TitleBar title="Edit QR code" breadcrumbs={breadcrumbs} primaryAction={null} />
       <QRCodeForm QRCode={QRCode} />
     </Page>
   )

--- a/qr-code/node/web/frontend/pages/qrcodes/new.jsx
+++ b/qr-code/node/web/frontend/pages/qrcodes/new.jsx
@@ -1,12 +1,16 @@
 import { Page } from '@shopify/polaris'
 import { TitleBar } from '@shopify/app-bridge-react'
-
 import { QRCodeForm } from '../../components'
 
 export default function ManageCode() {
+  const breadcrumbs = [{content: 'QR codes', url: '/' }]
+
   return (
     <Page>
-      <TitleBar title="Create new QR code" primaryAction={null} />
+      <TitleBar 
+      title="Create new QR code"
+      breadcrumbs={breadcrumbs} 
+      primaryAction={null} />
       <QRCodeForm />
     </Page>
   )


### PR DESCRIPTION
Closes: [#337](https://github.com/Shopify/first-party-library-planning/issues/337)

Added breadcrumbs to new QR code and edit QR code from to allow the user to click on the link to return back to `QR codes` main page. 

Changed main page name from `My QR Codes` to `QR codes` 


https://user-images.githubusercontent.com/78764587/173095267-642dff8e-c7aa-4a95-a5fe-64c8290476bf.mov

