### PR TITLE
feat: add mobile view for index table

### DIFF
--- a/qr-code/node/web/frontend/components/QRCodeForm.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeForm.jsx
@@ -26,7 +26,7 @@ import { useShopifyQuery, useAuthenticatedFetch } from '../hooks'
 import { gql } from 'graphql-request'
 import { useForm, useField, notEmptyString } from '@shopify/react-form'
 
-import { productCheckoutURL, productViewURL } from '../helpers/product-urls'
+import { productCheckoutURL, productViewURL } from '../helpers'
 
 const NO_DISCOUNT_OPTION = { label: 'No discount', value: '' }
 

--- a/qr-code/node/web/frontend/components/QRCodeIndex.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeIndex.jsx
@@ -1,10 +1,59 @@
 import { useNavigate } from '@shopify/app-bridge-react'
 import { Card, Icon, IndexTable, Stack, TextStyle, Thumbnail, UnstyledLink } from '@shopify/polaris'
 import { DiamondAlertMajor, ImageMajor } from '@shopify/polaris-icons'
+import { useMedia } from '@shopify/react-hooks'
 import dayjs from 'dayjs'
+
+import {truncate} from '../helpers'
+
+function SmallScreenCard({ id, title, product, discountCode, scans, createdAt, navigate }) {
+  return (
+    <UnstyledLink onClick={() => navigate(`/qrcodes/${id}`)}>
+      <div style={{ padding: '0.75rem 1rem', borderBottom: '1px solid #E1E3E5' }}>
+        <Stack>
+          <Stack.Item>
+            <Thumbnail
+              source={product?.images?.edges[0]?.node?.url || ImageMajor}
+              alt="placeholder"
+              color="base"
+              size="small"
+            />
+          </Stack.Item>
+          <Stack.Item fill>
+            <Stack vertical={true}>
+              <Stack.Item>
+              <p>
+                <TextStyle variation="strong">{truncate(title, 35)}</TextStyle>
+              </p>
+              <p>{truncate(product?.title, 35)}</p>
+              <p>{dayjs(createdAt).format('MMMM D, YYYY')}</p>
+              </Stack.Item>
+              <div style={{display: 'flex'}}>
+                <div style={{flex: '3'}}>
+                  <TextStyle variation="subdued">Discount</TextStyle>
+                  <p>{discountCode || '-'}</p>
+                </div>
+                <div style={{flex: '2'}}>
+                  <TextStyle variation="subdued">Scans</TextStyle>
+                  <p>{scans}</p>
+                </div>
+              </div>
+            </Stack>
+          </Stack.Item>
+        </Stack>
+      </div>
+    </UnstyledLink>
+  )
+}
 
 export function QRCodeIndex({ QRCodes, loading }) {
   const navigate = useNavigate()
+  const isSmallScreen = useMedia('(max-width: 640px)')
+
+  const smallScreenMarkup = QRCodes.map((QRCode) => (
+    <SmallScreenCard key={QRCode.id} navigate={navigate} {...QRCode}/>
+  ))
+
   const resourceName = {
     singular: 'QR code',
     plural: 'QR codes',
@@ -33,14 +82,14 @@ export function QRCodeIndex({ QRCodes, loading }) {
           </IndexTable.Cell>
           <IndexTable.Cell>
             <UnstyledLink data-primary-link url={`/qrcodes/${id}`}>
-              {title}
+              {truncate(title, 25)}
             </UnstyledLink>
           </IndexTable.Cell>
           <IndexTable.Cell>
             <Stack>
               {deletedProduct && <Icon source={DiamondAlertMajor} color="critical" />}
               <TextStyle variation={deletedProduct ? "negative" : null}>
-                {product.title}
+              {truncate(product?.title, 25)}
               </TextStyle>
             </Stack>
           </IndexTable.Cell>
@@ -56,22 +105,24 @@ export function QRCodeIndex({ QRCodes, loading }) {
 
   return (
     <Card>
-      <IndexTable
-        resourceName={resourceName}
-        itemCount={QRCodes.length}
-        headings={[
-          { title: 'Thumbnail', hidden: true },
-          { title: 'Title' },
-          { title: 'Product' },
-          { title: 'Discount' },
-          { title: 'Date created' },
-          { title: 'Scans' },
-        ]}
-        selectable={false}
-        loading={loading}
-      >
-        {rowMarkup}
-      </IndexTable>
+      {isSmallScreen ? smallScreenMarkup : (
+        <IndexTable
+          resourceName={resourceName}
+          itemCount={QRCodes.length}
+          headings={[
+            { title: 'Thumbnail', hidden: true },
+            { title: 'Title' },
+            { title: 'Product' },
+            { title: 'Discount' },
+            { title: 'Date created' },
+            { title: 'Scans' },
+          ]}
+          selectable={false}
+          loading={loading}
+          >
+          {rowMarkup}
+        </IndexTable>
+      )}
     </Card>
   )
 }

--- a/qr-code/node/web/frontend/helpers/index.js
+++ b/qr-code/node/web/frontend/helpers/index.js
@@ -1,0 +1,2 @@
+export * from './product-urls'
+export * from './truncate'

--- a/qr-code/node/web/frontend/helpers/truncate.js
+++ b/qr-code/node/web/frontend/helpers/truncate.js
@@ -1,0 +1,3 @@
+export function truncate(str, n) {
+  return str.length > n ? str.substr(0, n - 1) + '...' : str
+}

--- a/qr-code/node/web/frontend/package.json
+++ b/qr-code/node/web/frontend/package.json
@@ -18,6 +18,7 @@
     "@shopify/app-bridge-utils": "^3.1.0",
     "@shopify/polaris": "^9.11.0",
     "@shopify/react-form": "^1.1.19",
+    "@shopify/react-hooks": "^3.0.1",
     "@vitejs/plugin-react": "1.2.0",
     "cross-env": "^7.0.3",
     "dayjs": "^1.11.2",


### PR DESCRIPTION
## Background

The index view does not automatically display a mobile-optimized view on a small screen. We needed to add some custom markup to display a readable list of QR codes on mobile.

## Solution

- Add `smallScreenCard` to display the list of QR codes on mobile according to [Figma designs](https://www.figma.com/file/13VXYtW2vOltT8mD35K7uF/App-Template-and-Sample-App?node-id=86%3A34029).
- Add `@shopify/react-hooks` dependency to use media query utility.

![Screen Shot 2022-06-14 at 12 34 41 PM](https://user-images.githubusercontent.com/7654369/173674145-58b54fc6-038d-477c-a0d4-f5c6333d4c3a.png)

Known issue: Web appears to have a bug in it - when you load the screen in a small view, the app frame condenses the entire app into a narrow column. This is an issue outside of the app and has been reported to the web team.

## Testing this PR

Load app in large-screen view and _then_ switch to responsive view to check the layout against the Figma design. Loading or refreshing when your already in responsive view will trigger the issue described above. 
 