### PR TITLE
fix: move delete button to the bottom in Mobile View

### DIFF
--- a/qr-code/node/web/frontend/components/QRCodeForm.jsx
+++ b/qr-code/node/web/frontend/components/QRCodeForm.jsx
@@ -213,8 +213,8 @@ export function QRCodeForm({ QRCode: InitialQRCode }) {
     }
 
     const targetURL = deletedProduct || destination.value[0] === 'product'
-        ? productViewURL(data)
-        : productCheckoutURL(data)
+      ? productViewURL(data)
+      : productCheckoutURL(data)
 
     window.open(targetURL, '_blank', 'noreferrer,noopener')
   }, [QRCode, selectedProduct, destination, discountCode, handle, variantId])
@@ -238,8 +238,7 @@ export function QRCodeForm({ QRCode: InitialQRCode }) {
   const QRCodeURL = QRCode ? new URL(
     `/qrcodes/${QRCode.id}/image`,
     location.toString()
-    ).toString()
-    : null
+  ).toString() : null
 
   const imageSrc = selectedProduct?.images?.edges?.[0]?.node?.url
   const originalImageSrc = selectedProduct?.images?.[0]?.originalSrc
@@ -247,165 +246,158 @@ export function QRCodeForm({ QRCode: InitialQRCode }) {
 
   return (
     <Stack vertical>
-      {deletedProduct && (
-        <Banner
-          title="The product for this QR code no longer exists."
-          status="critical"
-        >
-          <p>
-            Scans will be directed to a 404 page, or you can choose another
-            product for this QR code.
-          </p>
-        </Banner>
-      )}
+      {deletedProduct && <Banner
+        title="The product for this QR code no longer exists."
+        status="critical"
+      >
+        <p>
+          Scans will be directed to a 404 page, or you can choose another product for this QR code.
+        </p>
+      </Banner>}
       <Layout>
-        <Layout.Section>
-          <Form>
-            <ContextualSaveBar
-              saveAction={{
-                label: 'Save',
-                onAction: submit,
-                loading: submitting,
-                disabled: submitting,
-              }}
-              discardAction={{
-                label: 'Discard',
-                onAction: reset,
-                loading: submitting,
-                disabled: submitting,
-              }}
-              visible={dirty}
-              fullWidth
-            />
-            <FormLayout>
-              <Card sectioned title="Title">
-                <TextField
-                  {...title}
-                  label="Title"
-                  labelHidden
-                  helpText="Only store staff can see this title"
-                />
-              </Card>
-              <Card
-                title="Product"
-                actions={[
-                  {
-                    content: productId.value
-                      ? 'Change product'
-                      : 'Select product',
-                    onAction: toggleResourcePicker,
-                  },
-                ]}
-              >
-                <Card.Section>
-                  {showResourcePicker && (
-                    <ResourcePicker
-                      resourceType="Product"
-                      showVariants={false}
-                      selectMultiple={false}
-                      onCancel={toggleResourcePicker}
-                      onSelection={handleProductChange}
-                      open
-                    />
-                  )}
-                  {productId.value ? (
-                    <Stack alignment="center">
-                      {imageSrc || originalImageSrc ? (
-                        <Thumbnail
-                          source={imageSrc || originalImageSrc}
-                          alt={altText}
-                        />
-                      ) : (
-                        <Thumbnail
-                          source={ImageMajor}
-                          color="base"
-                          size="small"
-                        />
-                      )}
-                      <TextStyle variation="strong">
-                        {selectedProduct.title}
-                      </TextStyle>
-                    </Stack>
-                  ) : (
-                    <Stack vertical spacing="extraTight">
-                      <Button onClick={toggleResourcePicker}>
-                        Select product
-                      </Button>
-                      {productId.error && (
-                        <Stack spacing="tight">
-                          <Icon source={AlertMinor} color="critical" />
-                          <TextStyle variation="negative">
-                            {productId.error}
-                          </TextStyle>
-                        </Stack>
-                      )}
-                    </Stack>
-                  )}
-                </Card.Section>
-                <Card.Section title="Scan Destination">
-                  <ChoiceList
-                    title="Scan destination"
-                    titleHidden
-                    choices={[
-                      { label: 'Link to product page', value: 'product' },
-                      {
-                        label: 'Link to checkout page with product in the cart',
-                        value: 'checkout',
-                      },
-                    ]}
-                    selected={destination.value}
-                    onChange={destination.onChange}
-                  />
-                </Card.Section>
-              </Card>
-              <Card
-                sectioned
-                title="Discount"
-                actions={[
-                  {
-                    content: 'Create discount',
-                    onAction: () =>
-                      navigate(
-                        {
-                          name: 'Discount',
-                          resource: {
-                            create: true,
-                          },
-                        },
-                        { target: 'new' }
-                      ),
-                  },
-                ]}
-              >
-                <Select
-                  label="discount code"
-                  options={discountOptions}
-                  onChange={handleDiscountChange}
-                  value={discountId.value}
-                  disabled={isLoadingDiscounts || discountsError}
-                  labelHidden
-                />
-              </Card>
-            </FormLayout>
-          </Form>
-        </Layout.Section>
-        <Layout.Section secondary>
-          <Card sectioned title="QR Code">
-            {QRCode ? (
-              <EmptyState 
-                imageContained={true} 
-                image={QRCodeURL} 
+      <Layout.Section>
+        <Form>
+          <ContextualSaveBar
+            saveAction={{
+              label: 'Save',
+              onAction: submit,
+              loading: submitting,
+              disabled: submitting,
+            }}
+            discardAction={{
+              label: 'Discard',
+              onAction: reset,
+              loading: submitting,
+              disabled: submitting,
+            }}
+            visible={dirty}
+            fullWidth
+          />
+          <FormLayout>
+            <Card sectioned title="Title">
+              <TextField
+                {...title}
+                label="Title"
+                labelHidden
+                helpText="Only store staff can see this title"
               />
-            ) : (
-              <EmptyState>
-                <p>Your QR code will appear here after you save.</p>
-              </EmptyState>
-            )}
-            <Stack vertical>
-              <Button
-                fullWidth primary download url={QRCodeURL} disabled={!QRCode || isDeleting}>
-                Download
-              </Button>
+            </Card>
+
+            <Card
+              title="Product"
+              actions={[
+                {
+                  content: productId.value
+                    ? 'Change product'
+                    : 'Select product',
+                  onAction: toggleResourcePicker,
+                },
+              ]}
+            >
+              <Card.Section>
+                {showResourcePicker && (
+                  <ResourcePicker
+                    resourceType="Product"
+                    showVariants={false}
+                    selectMultiple={false}
+                    onCancel={toggleResourcePicker}
+                    onSelection={handleProductChange}
+                    open
+                  />
+                )}
+                {productId.value ? (
+                  <Stack alignment="center">
+                    {(imageSrc || originalImageSrc) ? (
+                      <Thumbnail
+                        source={imageSrc || originalImageSrc}
+                        alt={altText}
+                      />
+                    ) : (
+                      <Thumbnail source={ImageMajor} color="base" size="small" />
+                    )}
+                    <TextStyle variation="strong">
+                      {selectedProduct.title}
+                    </TextStyle>
+                  </Stack>
+                ) : (
+                  <Stack vertical spacing="extraTight">
+                    <Button onClick={toggleResourcePicker}>
+                      Select product
+                    </Button>
+                    {productId.error && (
+                      <Stack spacing="tight">
+                        <Icon source={AlertMinor} color="critical" />
+                        <TextStyle variation="negative">
+                          {productId.error}
+                        </TextStyle>
+                      </Stack>
+                    )}
+                  </Stack>
+                )}
+              </Card.Section>
+              <Card.Section title="Scan Destination">
+                <ChoiceList
+                  title="Scan destination"
+                  titleHidden
+                  choices={[
+                    { label: 'Link to product page', value: 'product' },
+                    {
+                      label: 'Link to checkout page with product in the cart',
+                      value: 'checkout',
+                    },
+                  ]}
+                  selected={destination.value}
+                  onChange={destination.onChange}
+                />
+              </Card.Section>
+            </Card>
+            <Card
+              sectioned
+              title="Discount"
+              actions={[
+                {
+                  content: 'Create discount',
+                  onAction: () =>
+                    navigate(
+                      {
+                        name: 'Discount',
+                        resource: {
+                          create: true,
+                        },
+                      },
+                      { target: 'new' }
+                    ),
+                },
+              ]}
+            >
+              <Select
+                label="discount code"
+                options={discountOptions}
+                onChange={handleDiscountChange}
+                value={discountId.value}
+                disabled={isLoadingDiscounts || discountsError}
+                labelHidden
+              />
+            </Card>
+          </FormLayout>
+        </Form>
+      </Layout.Section>
+      <Layout.Section secondary>
+        <Card sectioned title="QR Code">
+          {QRCode ? (
+            <EmptyState
+              imageContained={true}
+              image={QRCodeURL}
+            />
+          ) : (
+            <EmptyState>
+              <p>Your QR code will appear here after you save.</p>
+            </EmptyState>
+          )}
+          <Stack vertical>
+            <Button fullWidth primary download url={QRCodeURL} disabled={!QRCode || isDeleting}>
+              Download
+            </Button>
               <Button
                 fullWidth
                 onClick={goToDestination}


### PR DESCRIPTION
closes: [#352](https://github.com/Shopify/first-party-library-planning/issues/352)

**What does PR Do**

Moves the `Delete QR Code` button from the `Form Layout` section, into its own section so it stays at the bottom on Mobile View. 

**Mobile View** 

![Uploading Screen Shot 2022-06-16 at 9.58.48 AM.png…]()

**Desktop View** 

<img width="1211" alt="Screen Shot 2022-06-16 at 9 59 31 AM" src="https://user-images.githubusercontent.com/78764587/174114571-3ac18e65-0626-456f-9b2a-425543db3cd4.png">


_Note: I ran a formatter and it updated the format of the JSX, so it shows more of the code being changed than was changed.  Let me know if you want me to revert the formatting back to what it was before. I reviewed the formatting change, and felt a lot of it was better_