### PR TITLE
Fix tests and add QR code validation

### DIFF
--- a/qr-code/node/web/__tests__/serve.js
+++ b/qr-code/node/web/__tests__/serve.js
@@ -1,6 +1,13 @@
 import path from "path";
 
-const port = 9528;
+// Hard-code some dummy values for the environment variables so that we can run the tests without needing to set them up
+// If the CLI ever evolves to run the tests itself, we can rely on it to give us these values
+process.env.SHOPIFY_API_KEY = "TEST_SHOPIFY_API_KEY";
+process.env.SHOPIFY_API_SECRET = "TEST_SHOPIFY_SECRET";
+process.env.HOST = "TEST_TUNNEL_URL";
+process.env.SCOPES = "TEST_SCOPES";
+process.env.BACKEND_PORT = 9528;
+process.env.FRONTEND_PORT = 9529;
 
 /**
  * @param {string} root
@@ -23,6 +30,5 @@ export async function serve(root, isProd) {
   }
 
   const { createServer } = await import(path.resolve(root, "index.js"));
-  process.env.PORT = port;
   return await createServer(root, isProd);
 }

--- a/qr-code/node/web/__tests__/setup.js
+++ b/qr-code/node/web/__tests__/setup.js
@@ -1,0 +1,21 @@
+import { beforeEach, vi } from "vitest";
+import { QRCodesDB } from "../qr-codes-db";
+
+beforeEach(async () => {
+  // Mock the database module so we don't end up creating / altering the real database
+  vi.mock(`${process.cwd()}/qr-codes-db.js`, async () => {
+    const actualModule = await vi.importActual(
+      `${process.cwd()}/qr-codes-db.js`
+    );
+
+    return {
+      QRCodesDB: {
+        ...actualModule.QRCodesDB,
+        init: () => Promise.resolve(),
+        __query: vi.fn(),
+      },
+    };
+  });
+
+  QRCodesDB.__query.mockReset();
+});

--- a/qr-code/node/web/helpers/qr-codes.js
+++ b/qr-code/node/web/helpers/qr-codes.js
@@ -34,8 +34,13 @@ const QR_CODE_ADMIN_QUERY = `
 `;
 
 export async function getQrCodeOr404(req, res, checkDomain = true) {
+  const id = req.params.id;
+  if (!id.match(/[0-9]+/)) {
+    res.status(404).send();
+  }
+
   try {
-    const response = await QRCodesDB.read(req.params.id);
+    const response = await QRCodesDB.read(id);
     if (
       response === undefined ||
       (checkDomain &&
@@ -57,16 +62,16 @@ export async function getShopUrlFromSession(req, res) {
   return `https://${session.shop}`;
 }
 
-/* 
-Expect body to contain
-title: string
-productId: string
-variantId: string
-handle: string
-discountId: string
-discountCode: string
-destination: string
- */
+/*
+  Expect body to contain
+  title: string
+  productId: string
+  variantId: string
+  handle: string
+  discountId: string
+  discountCode: string
+  destination: string
+*/
 export async function parseQrCodeBody(req, res) {
   return {
     title: req.body.title,

--- a/qr-code/node/web/index.js
+++ b/qr-code/node/web/index.js
@@ -22,13 +22,19 @@ const DEV_INDEX_PATH = `${process.cwd()}/frontend/`;
 const PROD_INDEX_PATH = `${process.cwd()}/dist/`;
 
 const dbFile = join(process.cwd(), "database.sqlite");
-const sessionDb = new Shopify.Session.SQLiteSessionStorage(dbFile);
-// Rip out the (technically private) SQLite DB from the session storage
-// so we can re-use it for storing QR codes. This is a temporary workaround
-// until we augment the SQLiteSessionStorage implementation to also accept
-// a db instance.
-QRCodesDB.db = sessionDb.db;
-QRCodesDB.init();
+
+let sessionDb;
+if (process.env.NODE_ENV === "test") {
+  sessionDb = new Shopify.Session.MemorySessionStorage();
+} else {
+  sessionDb = new Shopify.Session.SQLiteSessionStorage(dbFile);
+  // Rip out the (technically private) SQLite DB from the session storage
+  // so we can re-use it for storing QR codes. This is a temporary workaround
+  // until we augment the SQLiteSessionStorage implementation to also accept
+  // a db instance.
+  QRCodesDB.db = sessionDb.db;
+}
+await QRCodesDB.init();
 
 Shopify.Context.initialize({
   API_KEY: process.env.SHOPIFY_API_KEY,

--- a/qr-code/node/web/qr-codes-db.test.js
+++ b/qr-code/node/web/qr-codes-db.test.js
@@ -1,0 +1,198 @@
+import Shopify from "@shopify/shopify-api";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { QRCodesDB, QRCodeValidationError } from "./qr-codes-db";
+
+describe("QR code database", async () => {
+  describe("create", async () => {
+    const VALID_CREATE_DATA = {
+      shopDomain: "https://test-domain",
+      title: "dummy title",
+      productId: "gid://shopify/Product/123",
+      variantId: "gid://shopify/ProductVariant/456",
+      handle: "dummy_handle",
+      discountId: "gid://shopify/DiscountCodeNode/789",
+      discountCode: "dummy_discount",
+      destination: "product",
+    };
+
+    test("returns saved data", async () => {
+      QRCodesDB.__query.mockImplementation(() =>
+        Promise.resolve([{ id: 1234 }])
+      );
+
+      const id = await QRCodesDB.create(VALID_CREATE_DATA);
+
+      expect(QRCodesDB.__query).toHaveBeenCalledOnce();
+      expect(id).toEqual(1234);
+    });
+
+    test.each([
+      ["missing domain", { ...VALID_CREATE_DATA, shopDomain: undefined }],
+      ["missing title", { ...VALID_CREATE_DATA, title: undefined }],
+      ["missing productId", { ...VALID_CREATE_DATA, productId: undefined }],
+      ["missing variantId", { ...VALID_CREATE_DATA, variantId: undefined }],
+      ["missing handle", { ...VALID_CREATE_DATA, handle: undefined }],
+      ["missing destination", { ...VALID_CREATE_DATA, destination: undefined }],
+      ["invalid domain", { ...VALID_CREATE_DATA, shopDomain: "Not a domain" }],
+      ["invalid productId", { ...VALID_CREATE_DATA, productId: "Not an id" }],
+      ["invalid variantId", { ...VALID_CREATE_DATA, variantId: "Not an id" }],
+      ["invalid discountId", { ...VALID_CREATE_DATA, discountId: "Not an id" }],
+      ["invalid destination", { ...VALID_CREATE_DATA, destination: "Invalid" }],
+    ])("fails when %s", async (_scenario, data) => {
+      await expect(QRCodesDB.create(data)).rejects.toThrowError(
+        QRCodeValidationError
+      );
+      expect(QRCodesDB.__query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("update", async () => {
+    const VALID_UPDATE_DATA = {
+      id: 1234,
+      title: "dummy title",
+      productId: "gid://shopify/Product/123",
+      variantId: "gid://shopify/ProductVariant/456",
+      handle: "dummy_handle",
+      discountId: "gid://shopify/DiscountCodeNode/789",
+      discountCode: "dummy_discount",
+      destination: "checkout",
+    };
+
+    test("returns saved data", async () => {
+      QRCodesDB.__query.mockImplementation(() =>
+        Promise.resolve([{ id: 1234 }])
+      );
+
+      const id = await QRCodesDB.update(1234, VALID_UPDATE_DATA);
+
+      expect(QRCodesDB.__query).toHaveBeenCalledOnce();
+      expect(id).toBeTruthy();
+    });
+
+    test.each([
+      ["missing title", { ...VALID_UPDATE_DATA, title: undefined }],
+      ["missing productId", { ...VALID_UPDATE_DATA, productId: undefined }],
+      ["missing variantId", { ...VALID_UPDATE_DATA, variantId: undefined }],
+      ["missing handle", { ...VALID_UPDATE_DATA, handle: undefined }],
+      ["missing destination", { ...VALID_UPDATE_DATA, destination: undefined }],
+      ["invalid productId", { ...VALID_UPDATE_DATA, productId: "Not an id" }],
+      ["invalid variantId", { ...VALID_UPDATE_DATA, variantId: "Not an id" }],
+      ["invalid discountId", { ...VALID_UPDATE_DATA, discountId: "Not an id" }],
+      ["invalid destination", { ...VALID_UPDATE_DATA, destination: "Invalid" }],
+    ])("fails when %s", async (_scenario, data) => {
+      await expect(QRCodesDB.update(1234, data)).rejects.toThrowError(
+        QRCodeValidationError
+      );
+      expect(QRCodesDB.__query).not.toHaveBeenCalled();
+    });
+  });
+
+  test("list", async () => {
+    const codeResponse = [{ id: 1234 }, { id: 4321 }];
+    QRCodesDB.__query.mockImplementation(() => Promise.resolve(codeResponse));
+
+    const codes = await QRCodesDB.list("test-domain");
+
+    expect(QRCodesDB.__query).toHaveBeenCalledOnce();
+    expect(QRCodesDB.__query).toHaveBeenCalledWith(
+      expect.stringMatching(/WHERE shopDomain =/),
+      ["test-domain"]
+    );
+    expect(codes).toEqual(codeResponse);
+  });
+
+  describe("read", () => {
+    test("finds a result", async () => {
+      const codeResponse = [{ id: 1234 }];
+      QRCodesDB.__query.mockImplementation(() => Promise.resolve(codeResponse));
+
+      const code = await QRCodesDB.read(1234);
+
+      expect(QRCodesDB.__query).toHaveBeenCalledOnce();
+      expect(QRCodesDB.__query).toHaveBeenCalledWith(
+        expect.stringMatching(/WHERE id =/),
+        [1234]
+      );
+      expect(code).toEqual(codeResponse[0]);
+    });
+
+    test("handles result not found", async () => {
+      const codeResponse = [];
+      QRCodesDB.__query.mockImplementation(() => Promise.resolve(codeResponse));
+
+      const code = await QRCodesDB.read(1234);
+
+      expect(QRCodesDB.__query).toHaveBeenCalledOnce();
+      expect(QRCodesDB.__query).toHaveBeenCalledWith(
+        expect.stringMatching(/WHERE id =/),
+        [1234]
+      );
+      expect(code).toBeUndefined();
+    });
+  });
+
+  test("delete", async () => {
+    QRCodesDB.__query.mockImplementation(() => Promise.resolve());
+
+    const result = await QRCodesDB.delete(1234);
+
+    expect(QRCodesDB.__query).toHaveBeenCalledOnce();
+    expect(QRCodesDB.__query).toHaveBeenCalledWith(
+      expect.stringMatching(/DELETE FROM qr_codes\s+WHERE id =/),
+      [1234]
+    );
+    expect(result).toBeTruthy();
+  });
+
+  describe("scan functions", () => {
+    const qrCode = {
+      id: 1234,
+      shopDomain: "https://test-domain",
+      title: "dummy title",
+      productId: "gid://shopify/Product/123",
+      variantId: "gid://shopify/ProductVariant/456",
+      handle: "dummy_handle",
+      discountId: "gid://shopify/DiscountCodeNode/789",
+      discountCode: "dummy_discount",
+      destination: "product",
+    };
+
+    test("generateQrcodeDestinationUrl", async () => {
+      Shopify.Context.HOST_NAME = "test-host";
+
+      const result = await QRCodesDB.generateQrcodeDestinationUrl(qrCode);
+
+      expect(result).toMatch("https://test-host/qrcodes/1234/scan");
+    });
+
+    test("handleCodeScan with product destination", async () => {
+      Shopify.Context.HOST_NAME = "test-host";
+      QRCodesDB.__query.mockImplementation(() => Promise.resolve());
+
+      const result = await QRCodesDB.handleCodeScan({
+        ...qrCode,
+        destination: "product",
+      });
+
+      expect(QRCodesDB.__query).toHaveBeenCalledOnce();
+      expect(result).toMatch(
+        "https://test-domain/discount/dummy_discount?redirect=%2Fproducts%2Fdummy_handle"
+      );
+    });
+
+    test("handleCodeScan with checkout destination", async () => {
+      Shopify.Context.HOST_NAME = "test-host";
+      QRCodesDB.__query.mockImplementation(() => Promise.resolve());
+
+      const result = await QRCodesDB.handleCodeScan({
+        ...qrCode,
+        destination: "checkout",
+      });
+
+      expect(QRCodesDB.__query).toHaveBeenCalledOnce();
+      expect(result).toMatch(
+        "https://test-domain/cart/456:1?discount=dummy_discount"
+      );
+    });
+  });
+});

--- a/qr-code/node/web/vite.config.js
+++ b/qr-code/node/web/vite.config.js
@@ -2,6 +2,7 @@ const config = {
   test: {
     globals: true,
     exclude: ["./frontend/**", "./node_modules/**"],
+    setupFiles: "./__tests__/setup.js",
   },
 };
 


### PR DESCRIPTION
This PR does a couple of things:

- Change the tests to not use the SQLite database for sessions (using memory instead)
- Mock out the QR codes DB functions so they don't try to interact with a real database
- Adds some validation and tests to the public functions in the DB file.