### PR TITLE
Make QR code list full width

### DIFF
--- a/qr-code/node/web/frontend/pages/index.jsx
+++ b/qr-code/node/web/frontend/pages/index.jsx
@@ -69,7 +69,7 @@ export default function HomePage() {
     and include the empty state contents set above.
   */
   return (
-    <Page>
+    <Page fullWidth={!!qrCodesMarkup}>
       <TitleBar
         title="QR codes"
         primaryAction={{


### PR DESCRIPTION
This PR makes the QR code list full width, but only if there is actual QR code data to display - the empty state page continues to use the default page width.