### PR TITLE
Fix issue when setting up QRCodesDB

### DIFF
--- a/qr-code/node/web/package.json
+++ b/qr-code/node/web/package.json
@@ -12,8 +12,8 @@
     "node": ">=14.13.1"
   },
   "dependencies": {
-    "@shopify/shopify-app-express": "^1.0.0",
-    "@shopify/shopify-app-session-storage-sqlite": "^1.0.0",
+    "@shopify/shopify-app-express": "^1.2.2",
+    "@shopify/shopify-app-session-storage-sqlite": "^1.2.0",
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",
     "qrcode": "^1.5.0",

--- a/qr-code/node/web/shopify.js
+++ b/qr-code/node/web/shopify.js
@@ -4,14 +4,15 @@ import { SQLiteSessionStorage } from "@shopify/shopify-app-session-storage-sqlit
 let { restResources } = await import(
   `@shopify/shopify-api/rest/admin/${LATEST_API_VERSION}`
 );
-
+import sqlite3 from "sqlite3";
 import { join } from "path";
+
 import { QRCodesDB } from "./qr-codes-db.js";
 
-const dbFile = join(process.cwd(), "database.sqlite");
-const sessionDb = new SQLiteSessionStorage(dbFile);
+const database = new sqlite3.Database(join(process.cwd(), "database.sqlite"));
+const sessionDb = new SQLiteSessionStorage(database);
 // Initialize SQLite DB
-QRCodesDB.db = sessionDb.db;
+QRCodesDB.db = database;
 QRCodesDB.init();
 
 const shopify = shopifyApp({


### PR DESCRIPTION
Fixes #136 

With some recent changes made to the sqlite package, the `db` value was no longer the sqlite database itself, but rather an internal reference.

The database property wasn't meant to be public to begin with, so we changed that package to allow creating instances with an `sqlite3.Database` object as well as with a filename.