### PR TITLE
Bump @shopify/shopify-app-express

### DIFF
--- a/qr-code/node/web/package.json
+++ b/qr-code/node/web/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.13.1"
   },
   "dependencies": {
-    "@shopify/shopify-app-express": "^1.2.2",
+    "@shopify/shopify-app-express": "^2.1.2",
     "@shopify/shopify-app-session-storage-sqlite": "^1.2.0",
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
Closes https://github.com/Shopify/cli/issues/2141

This PR updates the dependency on `@shopify/shopify-app-express` to the latest version, which fixes a bug while loading REST resources.